### PR TITLE
Fix syntax error with body font fallback

### DIFF
--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -52,7 +52,7 @@
 ================================================== */
 	body {
 		background: #fff;
-		font: 14px/21px "Raleway" "HelveticaNeue-Light", Arial, sans-serif;
+		font: 14px/21px "Raleway", "HelveticaNeue-Light", Arial, sans-serif;
 		color: #444;
 		-webkit-font-smoothing: antialiased; /* Fix for webkit rendering */
 		-webkit-text-size-adjust: 100%;


### PR DESCRIPTION
This caused the declaration to be ignored in Firefox on Ubuntu.
