### PR TITLE
Do not zero the side padding for nav items

### DIFF
--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -135,7 +135,7 @@ nav ul {
 nav ul li {
   display:inline-block;
   border-top:{{navborder}}px solid;
-  padding: {{navborder}}px 0;
+  padding: {{navborder}}px;
   *display:inline;
   zoom:1;
   line-height:normal;


### PR DESCRIPTION
If this is zeroed, and two long menu items are next to each other there's no separation, and the words collide and even overlap a little.
