### PR TITLE
Make template Jekyll 3.0 compatible

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,11 +7,10 @@ safe: false
 
 ### site serving configuration ###
 exclude: [CNAME, README.md, .gitignore]
-permalink: / ## disables post output
+permalink: /:title ## disables post output
 timezone: null
 lsi: false
 markdown: kramdown
-highlighter: pygments
 
 
 ### content configuration ###

--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -267,14 +267,14 @@
   ================================================== */
 
 
-.highlighttable {
+.highlight {
   color: #f8f8f2;
   table-layout: fixed;
   white-space: nowrap;
   width:90%;
 }
 
-.highlighttable pre, .highlighttable code { display:block; margin:0; padding:0; background: none; overflow:auto; word-wrap: normal; }
+.highlight pre, .highlight code { display:block; margin:0; padding:0; background: none; overflow:auto; word-wrap: normal; }
 
 .highlight, .linenodiv {
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWPQ1dU1BgABzQC7XXMTYQAAAABJRU5ErkJggg==);
@@ -282,11 +282,11 @@
   padding: 10px;
   margin-bottom:20px;
 }
-.linenodiv, .lineno { color: #ccc; }
+.gutter, .lineno { color: #ccc; }
 
-td.linenos { width: 40px; }
+td.gl { width: 40px; }
 
-.linenodiv {
+.gutter {
   border-right: none;
   padding: 10px;
   text-align: right;

--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -31,7 +31,7 @@ html { box-sizing: border-box; }
 code, pre { font-family: Monaco, Menlo, Consolas, "Courier New", monospace; }
 
 /* spesifically inline code */
-code {
+code, pre {
   background: rgba(255,255,255,0.2);
   display: inline;
   word-wrap: break-word;
@@ -47,7 +47,7 @@ pre {
   word-wrap: break-word;
 }
 
-.highlighttable { margin:20px 5%; }
+.highlight { margin:20px 5%; }
 
 
 /* ----- base elements ----- */


### PR DESCRIPTION
- Changed the perma-link setting to fix site generation
- Changed highlighter to rouge, which required some CSS changes. I think I caught most of the CSS tags to make the two versions similar, but I may have missed one or two. 
