### PR TITLE
update permalink in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ safe: false
 
 ### site serving configuration ###
 exclude: [CNAME, README.md, .gitignore]
-permalink: / ## disables post output
+permalink: /:title ## disables post output
 timezone: null
 lsi: false
 markdown: kramdown


### PR DESCRIPTION
can not make it work without this modification. jekyll and github-pages versions are:

- github-pages (134)
- jekyll (3.4.3)

I followed the guide, the usage part in README file. I got bare html pages, pages without head section, js and css links, but only content part unless I appended `:title` to permalink settings in _config.yml
